### PR TITLE
Fix for null bug caused due to the "!rs.wasNull()" check

### DIFF
--- a/src/main/java/org/rayjars/hibernate/JacksonUserType.java
+++ b/src/main/java/org/rayjars/hibernate/JacksonUserType.java
@@ -58,11 +58,9 @@ public abstract class JacksonUserType implements UserType {
 
     @Override
     public Object nullSafeGet(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws HibernateException, SQLException {
-        if (!rs.wasNull()) {
-            String content = rs.getString(names[0]);
-            if(content!=null){
-                return convertJsonToObject(content);
-            }
+        String content = rs.getString(names[0]);
+        if(content!=null){
+            return convertJsonToObject(content);
         }
         return null;
     }


### PR DESCRIPTION
The rs.wasNull() check refers to the *previous column* - not the current one. This is also documented here: http://fabriziofortino.github.io/articles/hibernate-json-usertype/#comment-1727946314